### PR TITLE
Remove unused Size interface, fix DragResizeProps typization

### DIFF
--- a/src/components/drag-resize/index.tsx
+++ b/src/components/drag-resize/index.tsx
@@ -4,8 +4,7 @@ import { usePersistFn } from 'ahooks';
 import { observer } from 'mobx-react-lite';
 import AutoScroller from './AutoScroller';
 
-interface Size {}
-interface DragResizeProps extends React.HTMLProps<HTMLDivElement> {
+interface DragResizeProps extends Omit<HTMLProps<HTMLDivElement>, 'onResize'> {
   onResize: ({ width, x }: { width: number; x: number }) => void;
   /* 拖拽前的size */
   onResizeEnd?: ({ width, x }: { width: number; x: number }) => void;


### PR DESCRIPTION
Omitted `onResize` from `DragResizeProps` so we can safely override this handler in our interface wihout ts errors.