### PR TITLE
feat(locales): add RU locales

### DIFF
--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -1,2 +1,3 @@
 export * from "./en-us";
 export * from "./zh-cn";
+export * from "./ru-ru";

--- a/src/locales/ru-ru.ts
+++ b/src/locales/ru-ru.ts
@@ -1,0 +1,27 @@
+import { GanttLocale } from "../Gantt";
+
+export const ruRU: GanttLocale = Object.freeze({
+  today: 'Сегодня',
+  day: 'День',
+  days: 'Дни',
+  week: 'Неделя',
+  month: 'Месяц',
+  quarter: 'Квартал',
+  halfYear: 'Полугодие',
+  firstHalf: 'Первое полугодие',
+  secondHalf: 'Второе полугодие',
+  majorFormat: {
+    day: 'MMMM YYYY',
+    week: 'MMMM YYYY',
+    month: 'YYYY',
+    quarter: 'YYYY',
+    halfYear: 'YYYY',
+  },
+  minorFormat: {
+    day: 'D',
+    week: 'wo [неделя]',
+    month: 'MMMM',
+    quarter: '[К]Q',
+    halfYear: 'YYYY-',
+  },
+})


### PR DESCRIPTION
resolves #45 

I've noticed that not all translations are managed through locales. The patterns in `dayjs().format()` default to English and are independent of the locales provided.

@ahwgs is it possible to add locales configuration support to `dayjs`?

